### PR TITLE
Release/1.1.8

### DIFF
--- a/Core/HCS_CalculateScore.lua
+++ b/Core/HCS_CalculateScore.lua
@@ -218,7 +218,7 @@ function HCS_CalculateScore:RefreshScores(desc)
     if HCS_GameVersion < 30000 then
         HCS_LevelScalePercentage = (UnitLevel("player")  / 60) -- Classic
     else
-        HCS_LevelScalePercentage = (UnitLevel("player")  / 80) -- WOTLK
+        HCS_LevelScalePercentage = (UnitLevel("player")  / 85) -- Cataclysm
     end
 
     _G["CurrentXP"] = UnitXP("player")  -- CurrentXP

--- a/Core/HCS_DiscoveryScore.lua
+++ b/Core/HCS_DiscoveryScore.lua
@@ -18,7 +18,7 @@ function HCS_DiscoveryScore:UpdateDiscoveryScore()
             xpGained = 150
         elseif HCS_SODVersion == true and UnitLevel("player") == 25 then  -- Current level 25 for Season of Discovery
             xpGained = math.random(10, 50)
-        elseif HCS_GameVersion >= 30000 and UnitLevel("player") == 80 then
+        elseif HCS_GameVersion >= 30000 and UnitLevel("player") == 85 then
             xpGained = 250
         end
 

--- a/Core/HCS_Globals.lua
+++ b/Core/HCS_Globals.lua
@@ -1,7 +1,7 @@
 HCS_Globals = {}
 
 -- Game information
-HCS_GameVersion = select(4, GetBuildInfo())  -- if over 3000 than playing WOTLK
+HCS_GameVersion = select(4, GetBuildInfo())  -- if over 3000 than playing Cataclysm
 HCS_SODVersion, HCS_SODRealm = HCS_Utils:IsSeasonOfDiscoveryServer()
 
 -- Scaling Percentage

--- a/Core/HCS_KillingMobsScore.lua
+++ b/Core/HCS_KillingMobsScore.lua
@@ -46,8 +46,8 @@ local function GetMobKillHCScore(mobLevel)
             xpGain = 0
         end
 
-    -- WOTLK
-    elseif HCS_GameVersion >= 30000 and playerLevel == 80 then  -- WOTLK
+    -- Cataclysm
+    elseif HCS_GameVersion >= 30000 and playerLevel == 85 then  -- Cataclysm
         xpGain = 400
     end
 

--- a/Core/HCS_ProfessionsScore.lua
+++ b/Core/HCS_ProfessionsScore.lua
@@ -31,6 +31,8 @@ local LEVEL6 = 150
 -- WOTLK
 local LEVEL7 = 175
 local LEVEL8 = 200
+-- Cataclysm
+local LEVEL9 = 225
 
 local function between(x, a, b)
     return x >= a and x <= b
@@ -47,6 +49,7 @@ local function CalcScore(skilllevel)
     if between(skilllevel, 251, 300) then score = LEVEL6 end
     if between(skilllevel, 301, 375) then score = LEVEL7 end -- WOTLK
     if between(skilllevel, 376, 450) then score = LEVEL8 end -- WOTLK
+    if between(skilllevel, 451, 525) then score = LEVEL9 end -- Cataclysm
     if between(skilllevel, 2, 450) then score = score + skilllevel end
 
     return score

--- a/Data/HCS_RanksDB.lua
+++ b/Data/HCS_RanksDB.lua
@@ -1,4 +1,4 @@
-local wotlkScale = 1.33 -- 33%
+local catakScale = 1.33 -- 33%
 
 local function GetPointValue(points)
     local p = 0
@@ -6,7 +6,7 @@ local function GetPointValue(points)
     if HCS_GameVersion < 30000 then -- Classic
         p = points
     else                            
-        p = points * wotlkScale     -- Wotlk
+        p = points * catakScale     -- Cataclysm
     end
     
     return p

--- a/Events/HCS_PlayerCompletingQuestEvent.lua
+++ b/Events/HCS_PlayerCompletingQuestEvent.lua
@@ -61,8 +61,8 @@ local function OnQuestTurnedIn(event, questEvent, questID, xpReward, moneyReward
         xpReward = math.random(50, 150)
     end
   elseif HCS_GameVersion >= 30000 then
-    -- WOTLK
-    if playerLevel == 80 then
+    -- Cataclysm
+    if playerLevel == 85 then
         xpReward = 1200
     end
   end

--- a/Hardcore_Score.lua
+++ b/Hardcore_Score.lua
@@ -7,7 +7,7 @@ local _;
 Hardcore_Score = {}
 
 -- Globals
-HCS_Version = "1.1.7" 
+HCS_Version = "1.1.8" 
 HCS_Release = 20
 HCScore_Character = {
     name = "",
@@ -305,7 +305,7 @@ local options = {
             order = 21
         },
         addonInfoNote = {
-            name = "version 1.1.7 - authors: Avenroot, Caith, Fruze (level 60 testing)",
+            name = "version 1.1.8 - authors: Avenroot, Caith, Fruze (level 60 testing)",
             desc = "Addon Information",
             type = "description",
             fontSize = "medium",
@@ -686,7 +686,7 @@ function Hardcore_Score:init(event, name)
         end
 
         -- Print fun stuff for the player
-        print("|cff81b7e9".."Classic Score: ".."|r".."Welcome "..playerName.." to Classic Score v1.1.7.0  Lets GO!")
+        print("|cff81b7e9".."Classic Score: ".."|r".."Welcome "..playerName.." to Classic Score v1.1.8.0  Lets GO!")
 
         
         --[[

--- a/Hardcore_Score_Cata.toc
+++ b/Hardcore_Score_Cata.toc
@@ -1,8 +1,8 @@
-## Interface: 30403
-## Title: Classic Score 1.1.7
+## Interface: 40400
+## Title: Classic Score 1.1.8
 ## Notes: Your Classic score for your character
 ## Author: Avenroot, Caith
-## Version: 1.1.7
+## Version: 1.1.8
 ## DefaultState: enabled
 ## SavedVariables: Hardcore_Score_Settings
 ## SavedVariablesPerCharacter: HCScore_Character

--- a/Hardcore_Score_Vanilla.toc
+++ b/Hardcore_Score_Vanilla.toc
@@ -1,8 +1,8 @@
 ## Interface: 11502
-## Title: Classic Score 1.1.7
+## Title: Classic Score 1.1.8
 ## Notes: Your Classic score for your character
 ## Author: Avenroot, Caith
-## Version: 1.1.7
+## Version: 1.1.8
 ## DefaultState: enabled
 ## SavedVariables: Hardcore_Score_Settings
 ## SavedVariablesPerCharacter: HCScore_Character

--- a/Hardcore_Score_Vanilla.toc
+++ b/Hardcore_Score_Vanilla.toc
@@ -43,7 +43,6 @@ Data/HCS_MilestonesDB.lua
 Data/HCS_AchievementsDB.lua
 Data/HCS_RanksDB.lua
 
-
 UI/HCS_MainInfoFrameUI.lua
 UI/HCS_ScoreboardSummaryUI.lua
 UI/HCS_PointsLogUI.lua

--- a/Libs/AceConfig-3.0/AceConfig-3.0.xml
+++ b/Libs/AceConfig-3.0/AceConfig-3.0.xml
@@ -2,7 +2,7 @@
 ..\FrameXML\UI.xsd">
 	<Include file="AceConfigRegistry-3.0\AceConfigRegistry-3.0.xml"/>
 	<Include file="AceConfigCmd-3.0\AceConfigCmd-3.0.xml"/>
-	<Include file="AceConfigDialog-3.0\AceConfigDialog-3.0.xml"/>
+	<!--<Include file="AceConfigDialog-3.0\AceConfigDialog-3.0.xml"/>-->
 	<!--<Include file="AceConfigDropdown-3.0\AceConfigDropdown-3.0.xml"/>-->
 	<Script file="AceConfig-3.0.lua"/>
 </Ui>

--- a/Updates.txt
+++ b/Updates.txt
@@ -166,3 +166,5 @@ Version 1.1.7
 1. Updated for Season of Discovery phase 2 (1.15.2) NEW Runes!
 
 Version 1.1.8
+1. Overall update for Cataclysm to allow players to level from 80-85.
+2. Added support for Cataclysm crafting to level 525

--- a/Updates.txt
+++ b/Updates.txt
@@ -164,3 +164,5 @@ Version 1.1.6
 
 Version 1.1.7
 1. Updated for Season of Discovery phase 2 (1.15.2) NEW Runes!
+
+Version 1.1.8


### PR DESCRIPTION
Version 1.1.8
1. Overall update for Cataclysm to allow players to level from 80-85.
2. Added support for Cataclysm crafting to level 525